### PR TITLE
Fix CVE-2025-55163  vulnerability in  grpc-netty-shaded by updating libraries-bom to 26.61.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.26.0</version>
+        <version>26.61.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- Updated com.google.cloud:libraries-bom from 26.26.0 to 26.61.0
- This upgrades grpc-netty-shaded from 1.58.0 to 1.70.0
- Resolves vulnerability in io.grpc:grpc-netty-shaded dependency
- Resolves https://github.com/advisories/GHSA-prj3-ccx8-p6x4 vulnerability in Netty library