### PR TITLE
Fix CVE-2025-55163:  Update Google Cloud Libraries BOM to fix grpc-netty-shaded vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.26.0</version>
+        <version>26.72.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- Updated libraries-bom from 26.26.0 to 26.72.0
- This updates google-cloud-secretmanager from 2.29.0 to 2.80.0
- Fixes vulnerability in io.grpc:grpc-netty-shaded (1.58.0 -> 1.76.0)
- Resolves CVE-2025-55163 vulnerability in Netty library